### PR TITLE
added github pages.

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
+  "homepage": "https://vinkeln.github.io/ssr-editor-frontend",
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
@@ -15,7 +16,6 @@
   "dependencies": {
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
-    "@material-ui/core": "^4.12.4",
     "@mui/icons-material": "^7.3.2",
     "@mui/material": "^7.3.2",
     "@mui/styled-engine": "^7.3.2",

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -4,6 +4,7 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  base: '/ssr-editor-frontend'
   server: {
     proxy: {
       '/api': {


### PR DESCRIPTION
Added the homepage field to package.json and set the base option in vite.config.ts to /ssr-editor-frontend to ensure correct asset paths when deploying to GitHub Pages.
Removed the unused @material-ui/core dependency from package.json.